### PR TITLE
Add export to Quickbooks

### DIFF
--- a/src/commons/utils/time.util.ts
+++ b/src/commons/utils/time.util.ts
@@ -1,4 +1,5 @@
-export const convertTime = (date: Date) => {
+export const convertTime = (date: Date, format: string = "$3-$1-$2") => {
+  // TODO: Maybe make a builder to make this clearer?
   // something to consider: https://www.tutorialrepublic.com/faq/how-to-format-javascript-date-as-yyyy-mm-dd.php
   return date
     .toLocaleDateString("en-us", {
@@ -7,7 +8,7 @@ export const convertTime = (date: Date) => {
       day: "2-digit",
       timeZone: "America/Los_Angeles",
     })
-    .replace(/(\d+)\/(\d+)\/(\d+)/, "$3-$1-$2");
+    .replace(/(\d+)\/(\d+)\/(\d+)/, format);
 };
 
 export const convertTimeToText = (date: Date) => {


### PR DESCRIPTION
- Add a button to export a .csv file that can be directly imported into Quickbooks Online.
  - No column mapping is needed.
  - May need to edit due date.
- Allow convertTime to format into whatever pattern.
  - Definitely not an ideal design but I don't want to overkill a function.