### PR TITLE
Minor QoL changes to QBO export

### DIFF
--- a/src/pages/customer/report-customer-sale-page/components/CustomerSaleList.tsx
+++ b/src/pages/customer/report-customer-sale-page/components/CustomerSaleList.tsx
@@ -26,6 +26,24 @@ interface PaymentMethodMutationParam {
   status: string;
 }
 
+// Some customers we can't directly change the name to match qb.
+// An example would be the C customer.
+// It's not the job of the app to do this conversion, but
+// I can't think of a better place to do this so...
+// Ofc can just do it manually but yea...not very viable.
+const CUSTOMERNAME_TO_QBNAME = {
+  "Cristo Rey School": "Interfresh Inc",
+  C: "1 Time Customer",
+  "Loaves and Fisher": "Redwood (Customer)",
+};
+
+function getQuickbooksCustomerName(name: string) {
+  if (Object.hasOwn(CUSTOMERNAME_TO_QBNAME, name)) {
+    return CUSTOMERNAME_TO_QBNAME[name];
+  }
+  return name;
+}
+
 export default function CustomerSaleList({
   reports,
   reportQuery,
@@ -136,7 +154,7 @@ export default function CustomerSaleList({
         invoice_no: `${
           invoice.manualCode ? invoice.manualCode : invoice.orderCode
         }`,
-        customer: invoice.customerName,
+        customer: getQuickbooksCustomerName(invoice.customerName),
         invoice_date: convertTime(invoiceDate, "$1/$2/$3"),
         due_date: convertTime(dueDate, "$1/$2/$3"),
         item_amount: parseFloat(invoice.sale).toFixed(2),


### PR DESCRIPTION
- Add the "Terms" column to the export.
  - This is mostly to conform with what is usually inputted.
- When a sale is marked as CASH or CHECK, the memo of that invoice will be "Paid by X".
  - This is to make it slightly easier to manually create QB payments.
- During the export process, some customer names will be converted into QBO equivalent.
  - This is specifically added for Interfresh/Redwood. This is a temporary solution (although might be a permanent one) until there's a better way to address these two.