### PR TITLE
Minor visual fixes

### DIFF
--- a/src/pages/configure/view-product-page/components/InventoryToPrint.tsx
+++ b/src/pages/configure/view-product-page/components/InventoryToPrint.tsx
@@ -16,7 +16,7 @@ export default function InventoryToPrint({ printRef, products }) {
   }
 
   return (
-    <div ref={printRef} className="columns-2 gap-x-2 p-2 text-xs">
+    <div ref={printRef} className="columns-2 gap-x-2 p-4 text-xs">
       {Object.keys(locationMapping)
         .sort()
         .map((coolerName) => (

--- a/src/pages/customer/view-customer-order-page/components/CustomerOrderList.tsx
+++ b/src/pages/customer/view-customer-order-page/components/CustomerOrderList.tsx
@@ -226,7 +226,9 @@ export default function CustomerOrderList() {
             onClick={() => onToDetails(order.code)}
           >
             <div>#{order.manual_code ? order.manual_code : order.code}</div>
-            <div className="font-semibold">{order.customer_name}</div>
+            <div className="overflow-hidden text-ellipsis text-nowrap font-semibold">
+              {order.customer_name}
+            </div>
             <div className="text-sm">
               {convertTimeToText(new Date(order.expected_at))}
             </div>

--- a/src/pages/vendor/view-vendor-order-page/components/VendorOrderList.tsx
+++ b/src/pages/vendor/view-vendor-order-page/components/VendorOrderList.tsx
@@ -185,7 +185,9 @@ export default function VendorOrderList() {
             onClick={() => onToDetails(order.code)}
           >
             <div>#{order.manual_code ?? order.code}</div>
-            <div className="font-semibold">{order.vendor_name}</div>
+            <div className="overflow-hidden text-ellipsis text-nowrap font-semibold">
+              {order.vendor_name}
+            </div>
             <div className="text-sm">
               {convertTimeToText(new Date(order.expected_at))}
             </div>


### PR DESCRIPTION
- Add more padding when printing inventory.
  - Printer usually add their own margin automatically which eats into the left hand side.
- Fix a bug where a long customer name will wrap to a new line, making the rest of the component looks weird.