### PR TITLE
Minor fixes

### DIFF
--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -23,7 +23,10 @@ export default function Modal({
         </Transition.Child>
 
         <div className="fixed inset-0 overflow-y-auto bg-black bg-opacity-50">
-          <div className="flex min-h-full items-center justify-center p-4 text-center">
+          <div
+            className="flex min-h-full items-center justify-center p-4 text-center"
+            onClick={(e) => e.stopPropagation()}
+          >
             <Transition.Child
               as={Fragment}
               enter="ease-out duration-100"

--- a/src/pages/vendor/draft-vendor-order-page/components/VendorOrderForm.tsx
+++ b/src/pages/vendor/draft-vendor-order-page/components/VendorOrderForm.tsx
@@ -441,8 +441,6 @@ export default function VendorOrderForm({
                         setModalOpen(true);
                       }}
                     >
-                      {/* BUG: For some reasons CLICKing outside the modal trigger the div onClick,
-                      which reopen the modal again. Esc and onClose() still works. */}
                       <ImageModal
                         isOpen={imageModalIsOpen}
                         onClose={() => setModalOpen(false)}

--- a/src/pages/vendor/draft-vendor-order-page/components/VendorOrderForm.tsx
+++ b/src/pages/vendor/draft-vendor-order-page/components/VendorOrderForm.tsx
@@ -477,7 +477,7 @@ export default function VendorOrderForm({
                               const compressedFile = await imageCompression(
                                 file,
                                 {
-                                  maxSizeMB: 0.5,
+                                  maxSizeMB: 0.1,
                                   signal: imageCompressAborter.current.signal,
                                   onProgress: (progress) => {
                                     if (progress < 100) {


### PR DESCRIPTION
- Fix clicking outside modal doesn't close modal.
  - This is most prevalent in image modal.
- Reduce max image size from 500MB to 100MB.
  - Images are taking up a bit more spaces than anticipated. If this affects quality, this can be reverted.