### PR TITLE
VO refactors, autofill, and auto update packing slip status

### DIFF
--- a/src/components/Alert.tsx
+++ b/src/components/Alert.tsx
@@ -18,6 +18,17 @@ export default function Alert({ message, type }) {
     );
   }
 
+  if (type === "warning" || type === "warn") {
+    return (
+      <div className="alert alert-warning justify-center text-warning-content">
+        <div>
+          <BiError className="h-6 w-6"></BiError>
+          <span>{message}</span>
+        </div>
+      </div>
+    );
+  }
+
   if (type === "empty") {
     return (
       <div className="alert justify-center bg-base-300">

--- a/src/pages/customer/view-customer-order-detail-page/components/CustomerOrderPrint.tsx
+++ b/src/pages/customer/view-customer-order-detail-page/components/CustomerOrderPrint.tsx
@@ -5,6 +5,13 @@ import Modal from "../../../../components/Modal";
 import PackingSlipToPrint from "./PackingSlipToPrint";
 import NumberInput from "../../../../components/forms/NumberInput";
 import InvoiceToPrint from "./InvoiceToPrint";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import api from "../../../../stores/api";
+
+interface IOrderStatusMutation {
+  code: string;
+  newStatus: string;
+}
 
 export default function CustomerOrderPrint({ order }) {
   const [pallet, setPallet] = useState({ count: 1, list: [null] });
@@ -15,8 +22,40 @@ export default function CustomerOrderPrint({ order }) {
   const [isOpen, setIsOpen] = useState(false);
 
   const orderPrintAsPackingSlipRef = useRef<HTMLDivElement>(null);
+  const queryClient = useQueryClient();
+  const orderStatusMut = useMutation({
+    mutationFn: (data: IOrderStatusMutation) => {
+      return api.patch("customer-orders/status", null, {
+        params: {
+          code: data.code,
+          status: data.newStatus,
+        },
+      });
+    },
+    onSuccess: (response) => {
+      const newCustomerOrder = response.data;
+      queryClient.setQueryData(
+        ["customer-orders", order.code],
+        newCustomerOrder
+      );
+    },
+    onError: () => {
+      // Aside from param-related errors, there's also COMPLETED order
+      // and such so when that happens we reload the page.
+      // Return is kinda nice here because it'll wait for the invalidation to complete.
+      // ...or at least according to this https://tkdodo.eu/blog/mastering-mutations-in-react-query#awaited-promises
+      return queryClient.invalidateQueries({
+        queryKey: ["customer-orders", order.code],
+      });
+    },
+  });
   const handlePackingSlipPrint = useReactToPrint({
     content: () => orderPrintAsPackingSlipRef.current,
+    onAfterPrint: () => {
+      if (order.status === "PICKING") {
+        orderStatusMut.mutate({ code: order.code, newStatus: "CHECKING" });
+      }
+    },
   });
 
   const orderPrintAsInvoiceRef = useRef<HTMLDivElement>(null);

--- a/src/pages/customer/view-customer-order-detail-page/components/CustomerOrderPrint.tsx
+++ b/src/pages/customer/view-customer-order-detail-page/components/CustomerOrderPrint.tsx
@@ -19,7 +19,7 @@ export default function CustomerOrderPrint({ order }) {
   const handlePalletPrint = useReactToPrint({
     content: () => palletLabelToPrintRef.current,
   });
-  const [isOpen, setIsOpen] = useState(false);
+  const [isPalletModalOpen, setIsPalletModalOpen] = useState(false);
 
   const orderPrintAsPackingSlipRef = useRef<HTMLDivElement>(null);
   const queryClient = useQueryClient();
@@ -80,11 +80,11 @@ export default function CustomerOrderPrint({ order }) {
   };
 
   const onCloseModal = () => {
-    setIsOpen(false);
+    setIsPalletModalOpen(false);
   };
 
   const onOpenModal = () => {
-    setIsOpen(true);
+    setIsPalletModalOpen(true);
   };
 
   return (
@@ -98,7 +98,7 @@ export default function CustomerOrderPrint({ order }) {
       </div>
 
       {/* Pallet modal */}
-      <Modal isOpen={isOpen} onClose={onCloseModal}>
+      <Modal isOpen={isPalletModalOpen} onClose={onCloseModal}>
         <div className="custom-card text-left">
           <div className="flex justify-end">
             <button

--- a/src/pages/customer/view-customer-order-detail-page/components/CustomerOrderPrint.tsx
+++ b/src/pages/customer/view-customer-order-detail-page/components/CustomerOrderPrint.tsx
@@ -7,10 +7,11 @@ import NumberInput from "../../../../components/forms/NumberInput";
 import InvoiceToPrint from "./InvoiceToPrint";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import api from "../../../../stores/api";
+import { OrderStatus } from "../../../../commons/enums/order-status.enum";
 
 interface IOrderStatusMutation {
   code: string;
-  newStatus: string;
+  newStatus: OrderStatus;
 }
 
 export default function CustomerOrderPrint({ order }) {
@@ -52,8 +53,11 @@ export default function CustomerOrderPrint({ order }) {
   const handlePackingSlipPrint = useReactToPrint({
     content: () => orderPrintAsPackingSlipRef.current,
     onAfterPrint: () => {
-      if (order.status === "PICKING") {
-        orderStatusMut.mutate({ code: order.code, newStatus: "CHECKING" });
+      if (order.status === OrderStatus.PICKING) {
+        orderStatusMut.mutate({
+          code: order.code,
+          newStatus: OrderStatus.CHECKING,
+        });
       }
     },
   });

--- a/src/pages/vendor/draft-vendor-order-page/components/VendorOrderForm.tsx
+++ b/src/pages/vendor/draft-vendor-order-page/components/VendorOrderForm.tsx
@@ -75,7 +75,7 @@ export default function VendorOrderForm({
   onClear,
 }) {
   const navigate = useNavigate();
-  const [page, setPage] = useState(edit ? 1 : 0);
+  const [page, setPage] = useState(edit ? 1 : 1);
   // The products we visually see in the form.
   const [selectedProducts, setSelectedProducts] = useState(() =>
     computeSelectedProducts(allProducts, existingProducts)

--- a/src/pages/vendor/draft-vendor-order-page/components/VendorOrderForm.tsx
+++ b/src/pages/vendor/draft-vendor-order-page/components/VendorOrderForm.tsx
@@ -1,73 +1,89 @@
 import { useFormik } from "formik";
-import { useMemo, useRef, useState } from "react";
-import {
-  BiCloudUpload,
-  BiImage,
-  BiLeftArrowAlt,
-  BiRightArrowAlt,
-  BiX,
-} from "react-icons/bi";
-import { OrderStatus } from "../../../../commons/enums/order-status.enum";
-import Alert from "../../../../components/Alert";
-import Spinner from "../../../../components/Spinner";
-import Checkbox from "../../../../components/forms/Checkbox";
-import DateInput from "../../../../components/forms/DateInput";
-import NumberInput from "../../../../components/forms/NumberInput";
-import SearchSuggest from "../../../../components/forms/SearchSuggest";
-import SelectInput from "../../../../components/forms/SelectInput";
-import SelectSearch from "../../../../components/forms/SelectSearch";
-import TextInput from "../../../../components/forms/TextInput";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { BiCloudUpload } from "react-icons/bi";
 import api from "../../../../stores/api";
 import { handleTokenExpire } from "../../../../commons/utils/token.util";
 import { useNavigate } from "react-router-dom";
-import { niceVisualDecimal } from "../../../../commons/utils/fraction.util";
 import FileInput from "../../../../components/forms/FileInput";
-import ImageModal from "../../../../components/forms/ImageModal";
 import { useStateURL } from "../../../../commons/hooks/objecturl.hook";
 import imageCompression from "browser-image-compression";
 import { useQuery } from "@tanstack/react-query";
+import VendorOrderFormPage1 from "./VendorOrderFormPage1";
+import VendorOrderFormPage2 from "./VendorOrderFormPage2";
+import { convertTime } from "../../../../commons/utils/time.util";
+
+export interface ISelectedProduct {
+  id: string;
+  appear: number;
+  name: string;
+  units: Array<any>;
+  quantity: number;
+  price: string;
+  unit: string;
+
+  recent_cost?: any;
+}
+
+function computeSelectedProducts(
+  allProducts: Array<any>,
+  existingProducts: Array<any>
+) {
+  const selected: Array<ISelectedProduct> = [];
+
+  if (existingProducts.length >= 0) {
+    for (const product of allProducts) {
+      const similarProductOrders = existingProducts.filter(
+        (po) => po.product_name === product.name
+      );
+      if (similarProductOrders.length > 0) {
+        for (let i = 0; i < similarProductOrders.length; i++) {
+          // similar products in existing order
+          let appear = i + 1;
+          selected.push({
+            id: product.id,
+            appear: appear,
+            name: product.name,
+            units: product.units,
+            recent_cost: product.recent_cost,
+
+            quantity: similarProductOrders[i].quantity,
+            unit: similarProductOrders[i].unit_code.split("_")[1],
+            price: similarProductOrders[i].unit_price,
+          });
+        }
+      }
+    }
+  }
+  return selected;
+}
 
 export default function VendorOrderForm({
   edit,
-  initialData,
-  fetchData,
-  vendors,
-  editedProducts,
-  allProducts,
   onClear,
+  vendors,
+  allProducts,
+  initialData,
+  existingProducts,
 }) {
+  const selected = useMemo(
+    () => computeSelectedProducts(allProducts, existingProducts),
+    [allProducts, existingProducts]
+  );
+
   const navigate = useNavigate();
   const [formState, setFormState] = useState({
+    untouched: !edit,
     success: "",
     error: "",
   });
-  const [page, setPage] = useState(0);
-  // NOTE: This might not need to be a state. May change later.
-  const [selectedProducts, setSelectedProducts] = useState(
-    editedProducts ? editedProducts : []
-  );
-
-  const [search, setSearch] = useState("");
-  const filteredProducts =
-    search === ""
-      ? allProducts
-      : allProducts.filter((product) =>
-          product.name
-            .toLowerCase()
-            .replace(/\s+/g, "")
-            .includes(search.toLowerCase().replace(/\s+/g, ""))
-        );
+  const [page, setPage] = useState(edit ? 1 : 0);
+  const [selectedProducts, setSelectedProducts] = useState(selected);
 
   const imageCompressAborter = useRef(new AbortController());
 
-  const [imageModalIsOpen, setModalOpen] = useState(false);
-
-  // NOTE: This might not need to be a state. May change later.
-  const [fetchDataa, setFetchDataa] = useState(fetchData);
-
   const vendorOrderForm = useFormik({
     enableReinitialize: true,
-    initialValues: initialData,
+    initialValues: { ...initialData },
     onSubmit: async (data) => {
       setFormState((prev) => ({
         ...prev,
@@ -84,45 +100,20 @@ export default function VendorOrderForm({
         // Ensure this is either true-ish or null, no empty string allowed.
         // Makes it easier to deal with later.
         reqData["manualCode"] = data["manualCode"] ? data["manualCode"] : null;
-        const properties = Object.keys(data).sort();
-        for (const property of properties) {
-          if (property.includes("price")) {
-            const [id, appear] = property.replace("price", "").split("-");
-            const selected = selectedProducts.find(
-              (p) => p.id === +id && p.appear === +appear
-            );
-            if (selected) {
-              productOrders.set(`${selected.id}-${selected.appear}`, {
-                productName: selected.name,
-                unitPrice: data[property] ? data[property] : "",
-              });
-            }
-          } else if (property.includes("quantity")) {
-            const [id, appear] = property.replace("quantity", "").split("-");
-            const selected = selectedProducts.find(
-              (p) => p.id === +id && p.appear === +appear
-            );
-            if (selected) {
-              productOrders.set(`${selected.id}-${selected.appear}`, {
-                ...productOrders.get(`${selected.id}-${selected.appear}`),
-                quantity: data[property],
-              });
-            }
-          } else if (property.includes("unit")) {
-            const [id, appear] = property.replace("unit", "").split("-");
-            const selected = selectedProducts.find(
-              (p) => p.id === +id && p.appear === +appear
-            );
-            if (selected) {
-              productOrders.set(`${selected.id}-${selected.appear}`, {
-                ...productOrders.get(`${selected.id}-${selected.appear}`),
-                unitCode: `${selected.id}_${data[property]}`,
-              });
-            }
-          }
+
+        for (const product of selectedProducts) {
+          productOrders.set(`${product.id}-${product.appear}`, {
+            productName: product.name,
+            unitPrice: product.price,
+            quantity: product.quantity,
+            unitCode: product.unit,
+          });
         }
         reqData["productVendorOrders"] = [...productOrders.values()];
         reqData["attachment"] = data["attachment"];
+
+        console.log(reqData);
+        return;
 
         if (edit) {
           reqData["code"] = data["code"];
@@ -157,6 +148,28 @@ export default function VendorOrderForm({
     },
   });
 
+  const isAutofillEnabled =
+    !edit && !!vendorOrderForm.values.attachment && formState.untouched;
+
+  const autofillQuery = useQuery({
+    queryKey: ["vendor-orders", "autofill"],
+    queryFn: async () => {
+      console.log("Requesting autofilling...");
+      try {
+        const result = await api.postForm(`/vendor-orders/autofill`, {
+          attachment: vendorOrderForm.values.attachment,
+        });
+        return result.data;
+      } catch (error) {
+        console.error(error);
+        return null;
+      }
+    },
+    // We only want autofill when it's a brand new order.
+    enabled: isAutofillEnabled,
+    refetchOnWindowFocus: false,
+  });
+
   const templateQuery = useQuery({
     queryKey: [
       "vendors",
@@ -178,7 +191,8 @@ export default function VendorOrderForm({
       }
     },
     // Suppress the warning when vendorName is not yet available.
-    enabled: !edit && !!vendorOrderForm.values["vendorName"],
+    enabled:
+      !isAutofillEnabled && !edit && !!vendorOrderForm.values["vendorName"],
     refetchOnWindowFocus: false,
   });
 
@@ -188,53 +202,52 @@ export default function VendorOrderForm({
 
   const imageURL = useStateURL(vendorOrderForm.values.attachment);
 
-  const total = useMemo(() => {
-    if (fetchDataa.prices?.length > 0) {
-      return niceVisualDecimal(
-        +fetchDataa.prices.reduce(
-          (prev, current) => prev + current.quantity * current.price,
-          0
-        )
-      );
-    } else return 0;
-  }, [fetchDataa.prices]);
+  // FIXME: Ew. Anyway we can get rid of this useEffect somehow?
+  useEffect(() => {
+    if (autofillQuery.data) {
+      console.log("Autofilling...");
+      const info = autofillQuery.data;
+      const vendor_name = info.vendor_name;
+      const date_received = info.date_received;
+      const products = info.products;
 
-  const updatePrice = (value: number, inputId: string) => {
-    let updatedPrices = [...fetchDataa.prices];
-    if (inputId.includes("quantity")) {
-      const [id, appear] = inputId.replace("quantity", "").split("-");
-      const index = updatedPrices.findIndex(
-        (p) => p.id === +id && p.appear === +appear
+      vendorOrderForm.setFieldValue("vendorName", vendor_name);
+      vendorOrderForm.setFieldValue(
+        "expectedAt",
+        convertTime(new Date(date_received))
       );
-      updatedPrices[index].quantity = value;
-    } else if (inputId.includes("price")) {
-      const [id, appear] = inputId.replace("price", "").split("-");
-      const index = updatedPrices.findIndex(
-        (p) => p.id === +id && p.appear === +appear
-      );
-      updatedPrices[index].price = value;
-    } else if (inputId.includes("remove")) {
-      const [id, appear] = inputId.replace("remove", "").split("-");
-      const index = updatedPrices.findIndex(
-        (p) => p.id === +id && p.appear === +appear
-      );
-      updatedPrices[index].quantity = 0;
-      updatedPrices[index].price = 0;
+
+      const selected: Array<ISelectedProduct> = [];
+      for (const product of allProducts) {
+        const appear = 1;
+        const found = products.find((p) => p.name === product.name);
+        if (found) {
+          selected.push({
+            id: product.id,
+            appear: appear,
+            name: product.name,
+            recent_cost: product.recent_cost,
+            units: product.units,
+
+            quantity: found.quantity,
+            price: "0",
+            unit: found.unit_code.split("_")[1],
+          });
+        }
+      }
+      setPage(0);
+      setSelectedProducts(selected);
+      setFormTouched();
     }
-    setFetchDataa((prev) => ({ ...prev, prices: updatedPrices }));
-  };
-
-  const handlePriceChange = (e, inputId: string) => {
-    vendorOrderForm.setFieldValue(inputId, e.target.value);
-    updatePrice(+e.target.value, inputId);
-  };
+  }, [autofillQuery.data]);
 
   const onClearForm = () => {
     onClear();
-    imageCompressAborter.current.abort();
+    // setFormState((prev) => ({ ...prev, untouched: false }));
+    // imageCompressAborter.current.abort();
   };
 
-  const onNextPage = async () => {
+  const onGoToPage2 = async () => {
     if (!edit && selectedProducts.length === 0) {
       if (templateQuery.isSuccess && templateQuery.data.length > 0) {
         const template = templateQuery.data;
@@ -286,508 +299,99 @@ export default function VendorOrderForm({
             }
           }
         }
-        setFetchDataa((prev) => ({ ...prev, prices: updatedPrices }));
         setSelectedProducts(selected);
+        setFormState((prev) => ({ ...prev, untouched: false }));
       }
     }
     setPage(1);
   };
 
-  const onPreviousPage = () => {
+  const onGoToPage1 = () => {
     setPage(0);
   };
 
-  const onChangeSearch = (e) => {
-    setSearch(e.target.value);
-  };
-
-  const onAddProduct = (product) => {
-    setSearch("");
-    const found = selectedProducts.filter((p) => p.name === product.name);
-    if (found.length >= product.units.length) {
-      // cannot add more of this product, but we'll bump them up the list for searching purpose
-      setSelectedProducts([
-        ...found,
-        ...selectedProducts.filter((p) => p.name !== product.name),
-      ]);
-      return;
-    }
-
-    let appear;
-    if (found.length === 0) {
-      // first time this product appears
-      appear = 1;
-    } else {
-      // this product appears more than 1 & less than the maximum time it's allowed to appear
-
-      // have to do this cuz if there are 3 units (so we'll have appear 1 -> 3) then we remove the 2nd one out of order
-      // we can't do found.length + 1 as appear.
-      const currentAppear = new Set();
-      for (const product of found) {
-        currentAppear.add(product.appear);
-      }
-      // find the appear that doesn't exist (e.g. 2)
-      for (let i = 1; i <= product.units.length; i++) {
-        if (!currentAppear.has(i)) {
-          appear = i;
-          break;
-        }
-      }
-    }
-    const selectedProduct = { ...product, appear: appear };
-    setSelectedProducts([
-      selectedProduct,
-      ...found,
-      ...selectedProducts.filter((p) => p.name !== product.name),
-    ]);
-    vendorOrderForm.setFieldValue(`quantity${product.id}-${appear}`, 0);
-    vendorOrderForm.setFieldValue(`price${product.id}-${appear}`, "0");
-  };
-
-  const onRemoveProduct = (id, appear) => {
-    setSearch("");
-    vendorOrderForm.setFieldValue(`quantity${id}-${appear}`, 0);
-    vendorOrderForm.setFieldValue(`unit${id}-${appear}`, "BOX");
-    vendorOrderForm.setFieldValue(`price${id}-${appear}`, "0");
-    updatePrice(0, `remove${id}-${appear}`);
-    setSelectedProducts(
-      selectedProducts.filter(
-        (product) => product.id !== id || product.appear !== appear
-      )
-    );
-  };
-
-  const onClearQuery = () => {
-    setSearch("");
+  const setFormTouched = () => {
+    setFormState((prev) => ({ ...prev, untouched: false }));
   };
 
   return (
     <form onSubmit={vendorOrderForm.handleSubmit}>
       {page === 0 ? (
-        <div className="custom-card mx-auto grid grid-cols-12 gap-x-2 xl:w-7/12">
-          {/* 1st page */}
-          <div className="col-span-12 mb-5 xl:col-span-6">
-            <label className="custom-label mb-2 inline-block">
-              <span>Order to vendor</span>
-              <span className="text-red-500">*</span>
-            </label>
-            <SelectSearch
-              name="vendor"
-              value={vendorOrderForm.values["vendorName"]}
-              setValue={(v) => vendorOrderForm.setFieldValue("vendorName", v)}
-              options={vendors.map((vendor) => vendor.name)}
-            />
-          </div>
-
-          <div className="col-span-12 mb-5 xl:col-span-6">
-            <label className="custom-label mb-2 inline-block">
-              <span>Manual code</span>
-            </label>
-            <TextInput
-              id="manual-code"
-              type="text"
-              placeholder={`Manual code`}
-              name="manualCode"
-              value={vendorOrderForm.values.manualCode}
-              onChange={vendorOrderForm.handleChange}
-            ></TextInput>
-          </div>
-
-          <div className="col-span-12 mb-5 xl:col-span-6">
-            <label htmlFor="expect" className="custom-label mb-2 inline-block">
-              Expected delivery date
-            </label>
-            <DateInput
-              id="expect"
-              min="2023-01-01"
-              max="2100-12-31"
-              placeholder="Expected Delivery Date"
-              name="expectedAt"
-              value={vendorOrderForm.values[`expectedAt`]}
-              onChange={(e) =>
-                vendorOrderForm.setFieldValue("expectedAt", e.target.value)
+        <div className="w-full">
+          <FileInput
+            accept="image/*"
+            handleFiles={async (files) => {
+              const file = files[0];
+              if (file.type.startsWith("image/")) {
+                try {
+                  const compressedFile = await imageCompression(file, {
+                    maxSizeMB: 0.1,
+                    maxWidthOrHeight: 768,
+                    signal: imageCompressAborter.current.signal,
+                    onProgress: (progress) => {
+                      if (progress < 100) {
+                        setIsCompressingImg(true);
+                      } else {
+                        setIsCompressingImg(false);
+                      }
+                    },
+                  });
+                  vendorOrderForm.setFieldValue("attachment", compressedFile);
+                  vendorOrderForm.setFieldValue("attachmentExists", true);
+                } catch (error) {
+                  setFormState((prev) => ({
+                    ...prev,
+                    error: error.message,
+                  }));
+                  vendorOrderForm.setFieldValue("attachment", null);
+                  vendorOrderForm.setFieldValue("attachmentExists", false);
+                  setTimeout(() => {
+                    setFormState((prev) => ({
+                      ...prev,
+                      error: "",
+                    }));
+                  }, 1500);
+                }
               }
-            ></DateInput>
-          </div>
-
-          <div className="col-span-12 mb-5 xl:col-span-6">
-            <label htmlFor="status" className="custom-label mb-2 inline-block">
-              Status
-            </label>
-            <SelectInput
-              name="status"
-              value={vendorOrderForm.values["status"]}
-              setValue={(v) => vendorOrderForm.setFieldValue("status", v)}
-              options={Object.values(OrderStatus).filter(
-                (status) =>
-                  status !== OrderStatus.PICKING &&
-                  status !== OrderStatus.SHIPPING &&
-                  status !== OrderStatus.CANCELED &&
-                  // status !== OrderStatus.COMPLETED
-                  status !== OrderStatus.DELIVERED
-              )}
-            ></SelectInput>
-          </div>
-
-          {vendorOrderForm.values[`vendorName`] && (
-            <button
-              type="button"
-              className="btn btn-primary col-span-12 mt-3"
-              onClick={onNextPage}
-              disabled={isFormLoading}
-            >
-              <span>Set product</span>
-              <span>
-                <BiRightArrowAlt className="ml-1 h-7 w-7"></BiRightArrowAlt>
-              </span>
-            </button>
-          )}
-          <button
-            type="button"
-            className="btn btn-accent col-span-12 mt-3"
-            onClick={onClearForm}
+            }}
           >
-            <span>Clear change(s)</span>
-          </button>
+            <span>
+              <BiCloudUpload className="h-8 w-8"></BiCloudUpload>
+            </span>
+            <div>Drag and drop image here</div>
+            <div>or click to browse</div>
+            <div>!! This is an experimental feature !!</div>
+          </FileInput>
+          <button onClick={() => setPage(0)}>Skip experimental feature</button>
         </div>
+      ) : page === 1 ? (
+        <VendorOrderFormPage1
+          form={vendorOrderForm}
+          vendors={vendors}
+          isFormLoading={isFormLoading}
+          onNextPage={onGoToPage2}
+          onClearForm={onClearForm}
+        />
       ) : (
         <>
-          {page === 1 && (
-            <div className="flex min-h-screen flex-col items-start gap-6 xl:flex-row-reverse">
-              <div className="custom-card w-full xl:sticky xl:top-[84px] xl:w-5/12">
-                <div className="mb-4 flex items-center">
-                  Total:
-                  <span className="mx-1 text-xl font-medium">${total}</span>
-                  <span>
-                    {`(${selectedProducts.length} ${
-                      selectedProducts.length > 1 ? "items" : "item"
-                    })`}
-                  </span>
-                </div>
-
-                <div className="my-5 flex items-center">
-                  <Checkbox
-                    id="test"
-                    name="test"
-                    label="Test"
-                    onChange={() =>
-                      vendorOrderForm.setFieldValue(
-                        "isTest",
-                        !vendorOrderForm.values["isTest"]
-                      )
-                    }
-                    checked={vendorOrderForm.values["isTest"]}
-                  ></Checkbox>
-                </div>
-
-                <div className="my-5 flex justify-between gap-2">
-                  {imageURL ? (
-                    <div
-                      className="custom-card sticker-primary relative w-full text-center hover:cursor-pointer dark:border-2"
-                      onClick={() => {
-                        setModalOpen(true);
-                      }}
-                    >
-                      <ImageModal
-                        isOpen={imageModalIsOpen}
-                        onClose={() => setModalOpen(false)}
-                        imageSrc={imageURL}
-                      />
-                      <button
-                        type="button"
-                        className="btn btn-circle btn-accent btn-sm absolute -right-4 -top-4 shadow-md"
-                        onClick={(e) => {
-                          e.stopPropagation(); // Stop propagation to div
-
-                          vendorOrderForm.setFieldValue("attachment", null);
-                          vendorOrderForm.setFieldValue(
-                            "attachmentExists",
-                            false
-                          );
-                        }}
-                      >
-                        <span>
-                          <BiX className="h-6 w-6"></BiX>
-                        </span>
-                      </button>
-                      <div className="hover:text-primary hover:underline">
-                        <span className="flex justify-center">
-                          <BiImage className="h-16 w-16"></BiImage>
-                        </span>
-                        <span>Click to view attachment</span>
-                      </div>
-                    </div>
-                  ) : vendorOrderForm.values.attachmentExists ||
-                    isCompressingImg ? (
-                    <div className="custom-card sticker-primary relative w-full text-center dark:border-2">
-                      {isCompressingImg && (
-                        <button
-                          type="button"
-                          className="btn btn-circle btn-accent btn-sm absolute -right-4 -top-4 shadow-md"
-                          onClick={(e) => {
-                            e.stopPropagation(); // Stop propagation to div
-
-                            imageCompressAborter.current.abort();
-                            imageCompressAborter.current =
-                              new AbortController();
-                            setIsCompressingImg(false);
-                          }}
-                        >
-                          <span>
-                            <BiX className="h-6 w-6"></BiX>
-                          </span>
-                        </button>
-                      )}
-                      <Spinner />
-                    </div>
-                  ) : (
-                    <div className="w-full">
-                      <FileInput
-                        accept="image/*"
-                        handleFiles={async (files) => {
-                          const file = files[0];
-                          if (file.type.startsWith("image/")) {
-                            try {
-                              const compressedFile = await imageCompression(
-                                file,
-                                {
-                                  maxSizeMB: 0.1,
-                                  signal: imageCompressAborter.current.signal,
-                                  onProgress: (progress) => {
-                                    if (progress < 100) {
-                                      setIsCompressingImg(true);
-                                    } else {
-                                      setIsCompressingImg(false);
-                                    }
-                                  },
-                                }
-                              );
-                              vendorOrderForm.setFieldValue(
-                                "attachment",
-                                compressedFile
-                              );
-                              vendorOrderForm.setFieldValue(
-                                "attachmentExists",
-                                true
-                              );
-                            } catch (error) {
-                              setFormState((prev) => ({
-                                ...prev,
-                                error: error.message,
-                              }));
-                              vendorOrderForm.setFieldValue("attachment", null);
-                              vendorOrderForm.setFieldValue(
-                                "attachmentExists",
-                                false
-                              );
-                              setTimeout(() => {
-                                setFormState((prev) => ({
-                                  ...prev,
-                                  error: "",
-                                }));
-                              }, 1500);
-                            }
-                          }
-                        }}
-                      >
-                        <span>
-                          <BiCloudUpload className="h-8 w-8"></BiCloudUpload>
-                        </span>
-                        <div>Drag and drop image here</div>
-                        <div>or click to browse</div>
-                      </FileInput>
-                    </div>
-                  )}
-                </div>
-
-                <div className="grid grid-cols-12 gap-3">
-                  <button
-                    type="button"
-                    className="btn-outline-primary btn col-span-6"
-                    onClick={onPreviousPage}
-                    disabled={isFormLoading}
-                  >
-                    <span>
-                      <BiLeftArrowAlt className="mr-1 h-7 w-7"></BiLeftArrowAlt>
-                    </span>
-                    <span>Go back</span>
-                  </button>
-                  <button
-                    type="submit"
-                    className="btn btn-primary col-span-6"
-                    disabled={
-                      initialData.status === "COMPLETED" ||
-                      isFormLoading ||
-                      (vendorOrderForm.values.attachmentExists && !imageURL)
-                    }
-                  >
-                    <span>{edit ? "Update" : "Create"}</span>
-                  </button>
-
-                  <button
-                    type="button"
-                    className="btn btn-accent col-span-12"
-                    onClick={onClearForm}
-                  >
-                    <span>Revert change(s)</span>
-                  </button>
-                </div>
-
-                <div>
-                  {isFormLoading && (
-                    <div className="mt-5">
-                      <Spinner></Spinner>
-                    </div>
-                  )}
-                  {formState.error && (
-                    <div className="mt-5">
-                      <Alert message={formState.error} type="error"></Alert>
-                    </div>
-                  )}
-                  {formState.success && (
-                    <div className="mt-5">
-                      <Alert message={formState.success} type="success"></Alert>
-                    </div>
-                  )}
-                </div>
-              </div>
-
-              <div className="mb-5 w-full xl:w-7/12">
-                <div className="mb-6">
-                  <SearchSuggest
-                    query={search}
-                    items={filteredProducts}
-                    onChange={(e) => onChangeSearch(e)}
-                    onFocus={() => setSearch("")}
-                    onSelect={onAddProduct}
-                    onClear={onClearQuery}
-                  ></SearchSuggest>
-                </div>
-
-                {selectedProducts && selectedProducts.length > 0 ? (
-                  <div className="flex flex-col gap-4">
-                    {selectedProducts.map((product) => (
-                      <div
-                        key={`${product.id}-${product.appear}`}
-                        className="custom-card relative w-full p-3"
-                      >
-                        <div className="mb-2 grid grid-cols-12 items-center gap-2">
-                          <div className="col-span-12 xl:col-span-4">
-                            <span className="text-lg font-semibold">
-                              {product.name}
-                            </span>
-                            <div className="custom-badge mt-1 bg-accent text-accent-content">
-                              <span>Product</span>
-                            </div>
-                          </div>
-                          <div className="col-span-6 xl:col-span-2">
-                            <label className="custom-label mb-2 inline-block">
-                              Qty
-                            </label>
-                            <NumberInput
-                              id={`quantity${product.id}-${product.appear}`}
-                              placeholder="Qty"
-                              name={`quantity${product.id}-${product.appear}`}
-                              value={
-                                vendorOrderForm.values[
-                                  `quantity${product.id}-${product.appear}`
-                                ]
-                              }
-                              onChange={(e) =>
-                                handlePriceChange(
-                                  e,
-                                  `quantity${product.id}-${product.appear}`
-                                )
-                              }
-                            ></NumberInput>
-                          </div>
-                          <div className="col-span-6 xl:col-span-2">
-                            <label className="custom-label mb-2 inline-block">
-                              Unit Price
-                            </label>
-                            <TextInput
-                              id={`price${product.id}-${product.appear}`}
-                              placeholder="Price"
-                              name={`price${product.id}-${product.appear}`}
-                              value={
-                                vendorOrderForm.values[
-                                  `price${product.id}-${product.appear}`
-                                ]
-                              }
-                              onChange={(e) =>
-                                handlePriceChange(
-                                  e,
-                                  `price${product.id}-${product.appear}`
-                                )
-                              }
-                            ></TextInput>
-                          </div>
-                          <div className="col-span-6 xl:col-span-2">
-                            <label className="custom-label mb-2 inline-block">
-                              Unit
-                            </label>
-                            <SelectInput
-                              name={`unit${product.id}-${product.appear}`}
-                              value={
-                                vendorOrderForm.values[
-                                  `unit${product.id}-${product.appear}`
-                                ]
-                              }
-                              setValue={(v) =>
-                                vendorOrderForm.setFieldValue(
-                                  `unit${product.id}-${product.appear}`,
-                                  v
-                                )
-                              }
-                              options={product.units.map(
-                                (unit) => unit.code.split("_")[1]
-                              )}
-                            ></SelectInput>
-                          </div>
-                          <div className="col-span-6 xl:col-span-2">
-                            <div className="custom-label mb-2">Amount</div>
-                            <div className="rounded-box flex h-12 items-center bg-base-300 px-3">
-                              {
-                                // Display amount to be more explicit for user.
-                                vendorOrderForm.values[
-                                  `price${product.id}-${product.appear}`
-                                ] === ""
-                                  ? 0
-                                  : niceVisualDecimal(
-                                      parseFloat(
-                                        (
-                                          vendorOrderForm.values[
-                                            `quantity${product.id}-${product.appear}`
-                                          ] *
-                                          vendorOrderForm.values[
-                                            `price${product.id}-${product.appear}`
-                                          ]
-                                        ).toString() // Silent linter.
-                                      )
-                                    )
-                              }
-                            </div>
-                          </div>
-                        </div>
-                        <button
-                          type="button"
-                          className="btn btn-circle btn-accent btn-sm absolute -right-4 -top-4 shadow-md"
-                          onClick={() =>
-                            onRemoveProduct(product.id, product.appear)
-                          }
-                        >
-                          <span>
-                            <BiX className="h-6 w-6"></BiX>
-                          </span>
-                        </button>
-                      </div>
-                    ))}
-                  </div>
-                ) : (
-                  <Alert message={"No product selected."} type="empty"></Alert>
-                )}
-              </div>
-            </div>
+          {page === 2 && (
+            <VendorOrderFormPage2
+              form={vendorOrderForm}
+              formState={formState}
+              newAllProducts={allProducts}
+              selectedProducts={selectedProducts}
+              isCompressingImg={isCompressingImg}
+              isFormLoading={isFormLoading}
+              edit={edit}
+              isCompleted={initialData.status === "COMPLETED"}
+              imageURL={imageURL}
+              setIsCompressingImg={setIsCompressingImg}
+              onClearForm={onClearForm}
+              onPreviousPage={onGoToPage1}
+              setFormState={setFormState}
+              setFormTouched={setFormTouched}
+              setSelectedProducts={setSelectedProducts}
+            />
           )}
         </>
       )}

--- a/src/pages/vendor/draft-vendor-order-page/components/VendorOrderFormContainer.tsx
+++ b/src/pages/vendor/draft-vendor-order-page/components/VendorOrderFormContainer.tsx
@@ -73,8 +73,8 @@ export default function VendorOrderFormContainer() {
       } else {
         const today = new Date();
 
-        allVendors = vendorQuery.data;
-        allProducts = productQuery.data;
+        allVendors = vendors;
+        allProducts = products;
         initialData = {
           vendorName: "",
           manualCode: "",
@@ -113,7 +113,7 @@ export default function VendorOrderFormContainer() {
           manualCode: order.manual_code ?? "",
           expectedAt: convertTime(new Date(order.expected_at)),
           attachment: attachmentQuery.isSuccess ? attachmentQuery.data : null,
-          attachmentExists: !!order.attachment,
+          isAttachmentExist: !!order.attachment,
         };
       }
     }
@@ -169,11 +169,11 @@ export default function VendorOrderFormContainer() {
     <div className="mb-12">
       <VendorOrderForm
         edit={!!params.code}
-        onClear={onClear}
         vendors={allVendors}
         allProducts={allProducts}
         initialData={initialData}
         existingProducts={existingProducts}
+        onClear={onClear}
       />
     </div>
   );

--- a/src/pages/vendor/draft-vendor-order-page/components/VendorOrderFormPage0.tsx
+++ b/src/pages/vendor/draft-vendor-order-page/components/VendorOrderFormPage0.tsx
@@ -1,0 +1,183 @@
+import imageCompression from "browser-image-compression";
+import FileInput from "../../../../components/forms/FileInput";
+import { BiCloudUpload } from "react-icons/bi";
+import { Dispatch, SetStateAction, useEffect, useRef, useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import api from "../../../../stores/api";
+import { convertTime } from "../../../../commons/utils/time.util";
+import { FormikProps } from "formik";
+import { IFormState } from "./VendorOrderForm";
+import Spinner from "../../../../components/Spinner";
+import Alert from "../../../../components/Alert";
+
+interface IPage0Prop {
+  form: FormikProps<any>;
+  onGoToPage1: () => void;
+  fillFormWithProducts: (products: Array<any>) => void;
+  setFormState: Dispatch<SetStateAction<IFormState>>;
+}
+
+export default function VendorOrderFormPage0({
+  form,
+  onGoToPage1,
+  setFormState,
+  fillFormWithProducts,
+}: IPage0Prop) {
+  const [isCompressingImg, setIsCompressingImg] = useState(false);
+  const imageCompressAborter = useRef(new AbortController());
+
+  const queryClient = useQueryClient();
+  const autofillQuery = useQuery({
+    queryKey: ["vendor-orders", "autofill"],
+    queryFn: async ({ signal }) => {
+      console.log("Requesting autofilling...");
+      const result = await api.postForm(
+        `/vendor-orders/autofill`,
+        {
+          attachment: form.values.attachment,
+        },
+        { signal: signal }
+      );
+      return result.data;
+    },
+    // This page is only displayed when the form is in create mode, which also means it has no attachment.
+    enabled: !!form.values.attachment,
+    refetchOnWindowFocus: false,
+    // By default, React Query will return cache data before doing API call.
+    // This is not what we want, and this cache is not reusable by query anyway.
+    gcTime: 0,
+    retry: false,
+  });
+
+  useEffect(() => {
+    if (autofillQuery.data) {
+      console.log("Autofilling...");
+      const info = autofillQuery.data;
+
+      const vendorName = info.vendor_name;
+      const dateReceived = info.date_received;
+      const products = info.products;
+      const manualCode = info.manualCode ?? "";
+
+      form.setFieldValue("vendorName", vendorName);
+      form.setFieldValue("expectedAt", convertTime(new Date(dateReceived)));
+      form.setFieldValue("manualCode", manualCode);
+
+      fillFormWithProducts(products);
+      onGoToPage1();
+    }
+  }, [autofillQuery.data]);
+
+  const onCancelCompression = () => {
+    imageCompressAborter.current.abort();
+    imageCompressAborter.current = new AbortController();
+    setIsCompressingImg(false);
+  };
+
+  const onCancelAutofilling = () => {
+    queryClient.cancelQueries({ queryKey: ["vendor-orders", "autofill"] });
+  };
+
+  return (
+    <div className="custom-card mx-auto grid grid-cols-12 gap-x-2 xl:w-7/12">
+      <div className="col-span-12 mb-5">
+        <Alert
+          message="Autofill is an experimental feature. It may not be accurate."
+          type="warning"
+        />
+      </div>
+
+      {isCompressingImg ? (
+        <div className="col-span-12 mb-5 flex flex-col items-center">
+          <div>Compressing</div>
+          <Spinner></Spinner>
+        </div>
+      ) : autofillQuery.isFetching ? (
+        // Have to check explicitly because Modal closing takes time while the state switch is instant.
+        // So while closing it'll display the wrong state.
+        <div className="col-span-12 mb-5 flex flex-col items-center">
+          <div>Filling</div>
+          <Spinner></Spinner>
+        </div>
+      ) : !autofillQuery.isError ? (
+        <div className="col-span-12 mb-5">
+          <FileInput
+            accept="image/*"
+            handleFiles={async (files) => {
+              const file = files[0];
+              if (file.type.startsWith("image/")) {
+                try {
+                  const compressedFile = await imageCompression(file, {
+                    maxSizeMB: 0.1,
+                    maxWidthOrHeight: 768,
+                    signal: imageCompressAborter.current.signal,
+                    onProgress: (progress) => {
+                      if (progress < 100) {
+                        setIsCompressingImg(true);
+                      } else {
+                        setIsCompressingImg(false);
+                      }
+                    },
+                  });
+                  form.setFieldValue("attachment", compressedFile);
+                  form.setFieldValue("attachmentExists", true);
+                } catch (error) {
+                  setFormState((prev) => ({
+                    ...prev,
+                    error: error.message,
+                  }));
+                  form.setFieldValue("attachment", null);
+                  form.setFieldValue("attachmentExists", false);
+                  setTimeout(() => {
+                    setFormState((prev) => ({
+                      ...prev,
+                      error: "",
+                    }));
+                  }, 1500);
+                }
+              }
+            }}
+          >
+            <span>
+              <BiCloudUpload className="h-8 w-8"></BiCloudUpload>
+            </span>
+            <div>Drag and drop image here</div>
+            <div>or click to browse</div>
+          </FileInput>
+        </div>
+      ) : (
+        <></>
+      )}
+
+      {isCompressingImg ? (
+        <button
+          type="button"
+          className="btn btn-accent col-span-12 mb-5"
+          onClick={() => {
+            onCancelCompression();
+          }}
+        >
+          Cancel compression
+        </button>
+      ) : (
+        <button
+          type="button"
+          className="btn btn-accent col-span-12 mb-5"
+          onClick={(e) => {
+            e.preventDefault();
+            if (autofillQuery.isFetching) onCancelAutofilling();
+            onGoToPage1();
+          }}
+        >
+          Skip to filling manually
+        </button>
+      )}
+
+      {autofillQuery.isError && (
+        <div className="col-span-12">
+          <Alert message="Unable to autofill." type="error" />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/pages/vendor/draft-vendor-order-page/components/VendorOrderFormPage0.tsx
+++ b/src/pages/vendor/draft-vendor-order-page/components/VendorOrderFormPage0.tsx
@@ -30,7 +30,6 @@ export default function VendorOrderFormPage0({
   const autofillQuery = useQuery({
     queryKey: ["vendor-orders", "autofill"],
     queryFn: async ({ signal }) => {
-      console.log("Requesting autofilling...");
       const result = await api.postForm(
         `/vendor-orders/autofill`,
         {
@@ -51,7 +50,6 @@ export default function VendorOrderFormPage0({
 
   useEffect(() => {
     if (autofillQuery.data) {
-      console.log("Autofilling...");
       const info = autofillQuery.data;
 
       const vendorName = info.vendor_name;

--- a/src/pages/vendor/draft-vendor-order-page/components/VendorOrderFormPage1.tsx
+++ b/src/pages/vendor/draft-vendor-order-page/components/VendorOrderFormPage1.tsx
@@ -1,0 +1,109 @@
+import { BiRightArrowAlt } from "react-icons/bi";
+import { OrderStatus } from "../../../../commons/enums/order-status.enum";
+import DateInput from "../../../../components/forms/DateInput";
+import SelectInput from "../../../../components/forms/SelectInput";
+import SelectSearch from "../../../../components/forms/SelectSearch";
+import TextInput from "../../../../components/forms/TextInput";
+
+interface IPage1Prop {
+  form;
+  vendors: Array<any>;
+  isFormLoading: boolean;
+  onNextPage: () => void;
+  onClearForm: () => void;
+}
+
+export default function VendorOrderFormPage1({
+  form,
+  vendors,
+  isFormLoading,
+  onNextPage,
+  onClearForm,
+}: IPage1Prop) {
+  return (
+    <div className="custom-card mx-auto grid grid-cols-12 gap-x-2 xl:w-7/12">
+      {/* 1st page */}
+      <div className="col-span-12 mb-5 xl:col-span-6">
+        <label className="custom-label mb-2 inline-block">
+          <span>Order to vendor</span>
+          <span className="text-red-500">*</span>
+        </label>
+        <SelectSearch
+          name="vendor"
+          value={form.values["vendorName"]}
+          setValue={(v) => form.setFieldValue("vendorName", v)}
+          options={vendors.map((vendor) => vendor.name)}
+        />
+      </div>
+
+      <div className="col-span-12 mb-5 xl:col-span-6">
+        <label className="custom-label mb-2 inline-block">
+          <span>Manual code</span>
+        </label>
+        <TextInput
+          id="manual-code"
+          type="text"
+          placeholder={`Manual code`}
+          name="manualCode"
+          value={form.values.manualCode}
+          onChange={form.handleChange}
+        ></TextInput>
+      </div>
+
+      <div className="col-span-12 mb-5 xl:col-span-6">
+        <label htmlFor="expect" className="custom-label mb-2 inline-block">
+          Expected delivery date
+        </label>
+        <DateInput
+          id="expect"
+          min="2023-01-01"
+          max="2100-12-31"
+          placeholder="Expected Delivery Date"
+          name="expectedAt"
+          value={form.values[`expectedAt`]}
+          onChange={(e) => form.setFieldValue("expectedAt", e.target.value)}
+        ></DateInput>
+      </div>
+
+      <div className="col-span-12 mb-5 xl:col-span-6">
+        <label htmlFor="status" className="custom-label mb-2 inline-block">
+          Status
+        </label>
+        <SelectInput
+          name="status"
+          value={form.values["status"]}
+          setValue={(v) => form.setFieldValue("status", v)}
+          options={Object.values(OrderStatus).filter(
+            (status) =>
+              status !== OrderStatus.PICKING &&
+              status !== OrderStatus.SHIPPING &&
+              status !== OrderStatus.CANCELED &&
+              // status !== OrderStatus.COMPLETED
+              status !== OrderStatus.DELIVERED
+          )}
+        ></SelectInput>
+      </div>
+
+      {form.values[`vendorName`] && (
+        <button
+          type="button"
+          className="btn btn-primary col-span-12 mt-3"
+          onClick={onNextPage}
+          disabled={isFormLoading}
+        >
+          <span>Set product</span>
+          <span>
+            <BiRightArrowAlt className="ml-1 h-7 w-7"></BiRightArrowAlt>
+          </span>
+        </button>
+      )}
+      <button
+        type="button"
+        className="btn btn-accent col-span-12 mt-3"
+        onClick={onClearForm}
+      >
+        <span>Clear change(s)</span>
+      </button>
+    </div>
+  );
+}

--- a/src/pages/vendor/draft-vendor-order-page/components/VendorOrderFormPage2.tsx
+++ b/src/pages/vendor/draft-vendor-order-page/components/VendorOrderFormPage2.tsx
@@ -1,0 +1,458 @@
+import { BiCloudUpload, BiImage, BiLeftArrowAlt, BiX } from "react-icons/bi";
+import Checkbox from "../../../../components/forms/Checkbox";
+import ImageModal from "../../../../components/forms/ImageModal";
+import Spinner from "../../../../components/Spinner";
+import FileInput from "../../../../components/forms/FileInput";
+import imageCompression from "browser-image-compression";
+import Alert from "../../../../components/Alert";
+import SearchSuggest from "../../../../components/forms/SearchSuggest";
+import NumberInput from "../../../../components/forms/NumberInput";
+import TextInput from "../../../../components/forms/TextInput";
+import SelectInput from "../../../../components/forms/SelectInput";
+import { niceVisualDecimal } from "../../../../commons/utils/fraction.util";
+import { Dispatch, SetStateAction, useMemo, useRef, useState } from "react";
+import { ISelectedProduct } from "./VendorOrderForm";
+
+interface IPage2Prop {
+  form;
+  formState;
+  newAllProducts: Array<any>;
+  selectedProducts: Array<ISelectedProduct>;
+  isCompressingImg: boolean;
+  isFormLoading: boolean;
+  edit: boolean;
+  isCompleted: boolean;
+  imageURL: string;
+  setIsCompressingImg;
+  onClearForm: () => void;
+  onPreviousPage: () => void;
+  setFormState;
+  setFormTouched: () => void;
+  setSelectedProducts: Dispatch<SetStateAction<Array<ISelectedProduct>>>;
+}
+
+export default function VendorOrderFormPage2({
+  form,
+  formState,
+  newAllProducts,
+  selectedProducts,
+  isCompressingImg,
+  isFormLoading,
+  edit,
+  isCompleted,
+  imageURL,
+  setIsCompressingImg,
+  onClearForm,
+  onPreviousPage,
+  setFormState,
+  setFormTouched,
+  setSelectedProducts,
+}: IPage2Prop) {
+  const [search, setSearch] = useState("");
+  const filteredProducts =
+    search === ""
+      ? newAllProducts
+      : newAllProducts.filter((product) =>
+          product.name
+            .toLowerCase()
+            .replace(/\s+/g, "")
+            .includes(search.toLowerCase().replace(/\s+/g, ""))
+        );
+  const total = useMemo(() => {
+    if (selectedProducts.length > 0) {
+      return niceVisualDecimal(
+        +selectedProducts.reduce(
+          (prev, current) => prev + current.quantity * +current.price,
+          0
+        )
+      );
+    }
+    return "0";
+  }, [selectedProducts]);
+
+  const [imageModalIsOpen, setModalOpen] = useState(false);
+  const imageCompressAborter = useRef(new AbortController());
+
+  const onClear = () => {
+    imageCompressAborter.current.abort();
+    imageCompressAborter.current = new AbortController();
+    setIsCompressingImg(false);
+    onClearForm();
+  };
+
+  const onAddProduct = (product) => {
+    setFormTouched();
+    setSearch("");
+
+    const found = selectedProducts.filter((p) => p.name === product.name);
+    if (found.length >= product.units.length) {
+      // cannot add more of this product, but we'll bump them up the list for searching purpose
+      setSelectedProducts([
+        ...found,
+        ...selectedProducts.filter((p) => p.name !== product.name),
+      ]);
+      return;
+    }
+
+    let appear;
+    if (found.length === 0) {
+      // first time this product appears
+      appear = 1;
+    } else {
+      // this product appears more than 1 & less than the maximum time it's allowed to appear
+
+      // have to do this cuz if there are 3 units (so we'll have appear 1 -> 3) then we remove the 2nd one out of order
+      // we can't do found.length + 1 as appear.
+      const currentAppear = new Set();
+      for (const product of found) {
+        currentAppear.add(product.appear);
+      }
+      // find the appear that doesn't exist (e.g. 2)
+      for (let i = 1; i <= product.units.length; i++) {
+        if (!currentAppear.has(i)) {
+          appear = i;
+          break;
+        }
+      }
+    }
+    const selectedProduct: ISelectedProduct = {
+      ...product,
+      appear: appear,
+      price: "0",
+      quantity: 0,
+      unit: "BOX",
+    };
+    setSelectedProducts([
+      selectedProduct,
+      ...found,
+      ...selectedProducts.filter((p) => p.name !== product.name),
+    ]);
+  };
+
+  const onRemoveProduct = (id, appear) => {
+    setSearch("");
+    setFormTouched();
+    setSelectedProducts(
+      selectedProducts.filter(
+        (product) => product.id !== id || product.appear !== appear
+      )
+    );
+  };
+
+  const onFieldChange = (
+    value: number | string,
+    inputId: string,
+    i: number
+  ) => {
+    let clone = [...selectedProducts];
+    if (inputId.includes("quantity")) {
+      clone[i].quantity = +value;
+    } else if (inputId.includes("price")) {
+      clone[i].price = "" + value;
+    } else if (inputId.includes("unit")) {
+      clone[i].unit = "" + value;
+    }
+    setSelectedProducts(clone);
+    setFormTouched();
+  };
+
+  return (
+    <div className="flex min-h-screen flex-col items-start gap-6 xl:flex-row-reverse">
+      <div className="custom-card w-full xl:sticky xl:top-[84px] xl:w-5/12">
+        <div className="mb-4 flex items-center">
+          Total:
+          <span className="mx-1 text-xl font-medium">${total}</span>
+          <span>
+            {`(${selectedProducts.length} ${
+              selectedProducts.length > 1 ? "items" : "item"
+            })`}
+          </span>
+        </div>
+
+        <div className="my-5 flex items-center">
+          <Checkbox
+            id="test"
+            name="test"
+            label="Test"
+            onChange={() =>
+              form.setFieldValue("isTest", !form.values["isTest"])
+            }
+            checked={form.values["isTest"]}
+          ></Checkbox>
+        </div>
+
+        <div className="my-5 flex justify-between gap-2">
+          {imageURL ? (
+            <div
+              className="custom-card sticker-primary relative w-full text-center hover:cursor-pointer dark:border-2"
+              onClick={() => {
+                setModalOpen(true);
+              }}
+            >
+              <ImageModal
+                isOpen={imageModalIsOpen}
+                onClose={() => setModalOpen(false)}
+                imageSrc={imageURL}
+              />
+              <button
+                type="button"
+                className="btn btn-circle btn-accent btn-sm absolute -right-4 -top-4 shadow-md"
+                onClick={(e) => {
+                  e.stopPropagation(); // Stop propagation to div
+
+                  form.setFieldValue("attachment", null);
+                  form.setFieldValue("attachmentExists", false);
+                }}
+              >
+                <span>
+                  <BiX className="h-6 w-6"></BiX>
+                </span>
+              </button>
+              <div className="hover:text-primary hover:underline">
+                <span className="flex justify-center">
+                  <BiImage className="h-16 w-16"></BiImage>
+                </span>
+                <span>Click to view attachment</span>
+              </div>
+            </div>
+          ) : form.values.attachmentExists || isCompressingImg ? (
+            <div className="custom-card sticker-primary relative w-full text-center dark:border-2">
+              {isCompressingImg && (
+                <button
+                  type="button"
+                  className="btn btn-circle btn-accent btn-sm absolute -right-4 -top-4 shadow-md"
+                  onClick={(e) => {
+                    e.stopPropagation(); // Stop propagation to div
+
+                    imageCompressAborter.current.abort();
+                    imageCompressAborter.current = new AbortController();
+                    setIsCompressingImg(false);
+                  }}
+                >
+                  <span>
+                    <BiX className="h-6 w-6"></BiX>
+                  </span>
+                </button>
+              )}
+              <Spinner />
+            </div>
+          ) : (
+            <div className="w-full">
+              <FileInput
+                accept="image/*"
+                handleFiles={async (files) => {
+                  const file = files[0];
+                  if (file.type.startsWith("image/")) {
+                    try {
+                      const compressedFile = await imageCompression(file, {
+                        maxSizeMB: 0.1,
+                        signal: imageCompressAborter.current.signal,
+                        onProgress: (progress) => {
+                          if (progress < 100) {
+                            setIsCompressingImg(true);
+                          } else {
+                            setIsCompressingImg(false);
+                          }
+                        },
+                      });
+                      form.setFieldValue("attachment", compressedFile);
+                      form.setFieldValue("attachmentExists", true);
+                    } catch (error) {
+                      setFormState((prev) => ({
+                        ...prev,
+                        error: error.message,
+                      }));
+                      form.setFieldValue("attachment", null);
+                      form.setFieldValue("attachmentExists", false);
+                      setTimeout(() => {
+                        setFormState((prev) => ({
+                          ...prev,
+                          error: "",
+                        }));
+                      }, 1500);
+                    }
+                  }
+                }}
+              >
+                <span>
+                  <BiCloudUpload className="h-8 w-8"></BiCloudUpload>
+                </span>
+                <div>Drag and drop image here</div>
+                <div>or click to browse</div>
+              </FileInput>
+            </div>
+          )}
+        </div>
+
+        <div className="grid grid-cols-12 gap-3">
+          <button
+            type="button"
+            className="btn-outline-primary btn col-span-6"
+            onClick={onPreviousPage}
+            disabled={isFormLoading}
+          >
+            <span>
+              <BiLeftArrowAlt className="mr-1 h-7 w-7"></BiLeftArrowAlt>
+            </span>
+            <span>Go back</span>
+          </button>
+          <button
+            type="submit"
+            className="btn btn-primary col-span-6"
+            disabled={
+              isCompleted ||
+              isFormLoading ||
+              (form.values.attachmentExists && !imageURL)
+            }
+          >
+            <span>{edit ? "Update" : "Create"}</span>
+          </button>
+
+          <button
+            type="button"
+            className="btn btn-accent col-span-12"
+            onClick={onClear}
+          >
+            <span>Revert change(s)</span>
+          </button>
+        </div>
+
+        <div>
+          {isFormLoading && (
+            <div className="mt-5">
+              <Spinner></Spinner>
+            </div>
+          )}
+          {formState.error && (
+            <div className="mt-5">
+              <Alert message={formState.error} type="error"></Alert>
+            </div>
+          )}
+          {formState.success && (
+            <div className="mt-5">
+              <Alert message={formState.success} type="success"></Alert>
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="mb-5 w-full xl:w-7/12">
+        <div className="mb-6">
+          <SearchSuggest
+            query={search}
+            items={filteredProducts}
+            onChange={(e) => setSearch(e.target.value)}
+            onFocus={() => setSearch("")}
+            onSelect={onAddProduct}
+            onClear={() => setSearch("")}
+          ></SearchSuggest>
+        </div>
+
+        {selectedProducts && selectedProducts.length > 0 ? (
+          <div className="flex flex-col gap-4">
+            {selectedProducts.map((product, i) => (
+              <div
+                key={`${product.id}-${product.appear}`}
+                className="custom-card relative w-full p-3"
+              >
+                <div className="mb-2 grid grid-cols-12 items-center gap-2">
+                  <div className="col-span-12 xl:col-span-4">
+                    <span className="text-lg font-semibold">
+                      {product.name}
+                    </span>
+                    <div className="custom-badge mt-1 bg-accent text-accent-content">
+                      <span>Product</span>
+                    </div>
+                  </div>
+                  <div className="col-span-6 xl:col-span-2">
+                    <label className="custom-label mb-2 inline-block">
+                      Qty
+                    </label>
+                    <NumberInput
+                      id={`quantity${product.id}-${product.appear}`}
+                      placeholder="Qty"
+                      name={`quantity${product.id}-${product.appear}`}
+                      value={product.quantity}
+                      onChange={(e) =>
+                        onFieldChange(
+                          +e.target.value,
+                          `products.quantity${product.id}-${product.appear}`,
+                          i
+                        )
+                      }
+                    ></NumberInput>
+                  </div>
+                  <div className="col-span-6 xl:col-span-2">
+                    <label className="custom-label mb-2 inline-block">
+                      Unit Price
+                    </label>
+                    <TextInput
+                      id={`price${product.id}-${product.appear}`}
+                      placeholder="Price"
+                      name={`price${product.id}-${product.appear}`}
+                      value={product.price}
+                      onChange={(e) =>
+                        onFieldChange(
+                          e.target.value,
+                          `products.price${product.id}-${product.appear}`,
+                          i
+                        )
+                      }
+                    ></TextInput>
+                  </div>
+                  <div className="col-span-6 xl:col-span-2">
+                    <label className="custom-label mb-2 inline-block">
+                      Unit
+                    </label>
+                    <SelectInput
+                      name={`unit${product.id}-${product.appear}`}
+                      value={product.unit}
+                      setValue={(v) =>
+                        onFieldChange(
+                          v,
+                          `unit${product.id}-${product.appear}`,
+                          i
+                        )
+                      }
+                      options={product.units.map(
+                        (unit) => unit.code.split("_")[1]
+                      )}
+                    ></SelectInput>
+                  </div>
+                  <div className="col-span-6 xl:col-span-2">
+                    <div className="custom-label mb-2">Amount</div>
+                    <div className="rounded-box flex h-12 items-center bg-base-300 px-3">
+                      {
+                        // Display amount to be more explicit for user.
+                        form.values[
+                          `products.price${product.id}-${product.appear}`
+                        ] === ""
+                          ? 0
+                          : niceVisualDecimal(
+                              parseFloat(
+                                (product.quantity * +product.price).toString() // Silent linter.
+                              )
+                            )
+                      }
+                    </div>
+                  </div>
+                </div>
+                <button
+                  type="button"
+                  className="btn btn-circle btn-accent btn-sm absolute -right-4 -top-4 shadow-md"
+                  onClick={() => onRemoveProduct(product.id, product.appear)}
+                >
+                  <span>
+                    <BiX className="h-6 w-6"></BiX>
+                  </span>
+                </button>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <Alert message={"No product selected."} type="empty"></Alert>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/vendor/draft-vendor-order-page/components/VendorOrderFormPage2.tsx
+++ b/src/pages/vendor/draft-vendor-order-page/components/VendorOrderFormPage2.tsx
@@ -1,4 +1,10 @@
-import { BiCloudUpload, BiImage, BiLeftArrowAlt, BiX } from "react-icons/bi";
+import {
+  BiCloudUpload,
+  BiImage,
+  BiLeftArrowAlt,
+  BiTrash,
+  BiX,
+} from "react-icons/bi";
 import Checkbox from "../../../../components/forms/Checkbox";
 import ImageModal from "../../../../components/forms/ImageModal";
 import Spinner from "../../../../components/Spinner";
@@ -133,6 +139,12 @@ export default function VendorOrderFormPage2({
         (product) => product.id !== id || product.appear !== appear
       )
     );
+  };
+
+  const onRemoveAllProducts = () => {
+    setSearch("");
+    markFormFilled();
+    setSelectedProducts([]);
   };
 
   const onFieldChange = (
@@ -335,7 +347,7 @@ export default function VendorOrderFormPage2({
       </div>
 
       <div className="mb-5 w-full xl:w-7/12">
-        <div className="mb-6">
+        <div className="mb-6 flex gap-2">
           <SearchSuggest
             query={search}
             items={filteredProducts}
@@ -344,6 +356,15 @@ export default function VendorOrderFormPage2({
             onSelect={onAddProduct}
             onClear={() => setSearch("")}
           ></SearchSuggest>
+          <button
+            type="button"
+            className="btn btn-error col-span-12 md:col-span-6"
+            onClick={onRemoveAllProducts}
+          >
+            <span>
+              <BiTrash className="h-6 w-6"></BiTrash>
+            </span>
+          </button>
         </div>
 
         {selectedProducts && selectedProducts.length > 0 ? (


### PR DESCRIPTION
- Implement autofill mechanic.
  - Currently disabled since the matching process on the backend is still poor, but the method is there.
  - Add a button to remove all products (as opposed to clear form) in case the autofill hallucinates.
- Refactor VO to split its pages into components.
  - Aside from simplifying the complexity arise from autofilling, this also clean up states and logics.
- Attempting to print a customer order now change its status to CHECKING automatically.
  - This also applies to when printing from the "View CO" page. Note that the current implementation of this is inefficient as it'll issue a request per order. A batch update endpoint will be considered.
- The money total displayed on the "View CO" now requires an explicit click to view.
  - Just in case somone wants to project it on a big 4K OLED TV screen :)